### PR TITLE
Update package.json

### DIFF
--- a/app/docs/package.json
+++ b/app/docs/package.json
@@ -10,7 +10,7 @@
     "axios": "^0.11.0",
     "cookie-parser": "~1.4.1",
     "debug": "~2.2.0",
-    "ejs": "~2.4.1",
+    "ejs": "~2.5.5",
     "express": "~4.13.4",
     "getstream": "^3.2.0",
     "mapbox-geocoding": "^0.1.4",


### PR DESCRIPTION
fix security vulnerability as nodejs ejs version older than 2.5.5 is vulnerable to a denial-of-service due to weak input validation in the ejs.renderFile()